### PR TITLE
fix _getRoot method

### DIFF
--- a/lib/renderer/src/engine/base.js
+++ b/lib/renderer/src/engine/base.js
@@ -172,7 +172,7 @@ var Renderer = (function() {
       var level = _.compact(outputPath
           .replace(path.normalize(this.options.dest + '/'), '')
           .replace('index.html', '')
-          .split('/')
+          .split(path.sep)
       ).length;
       var root = '';
       if (level === 0) {


### PR DESCRIPTION
_getRoot method had incorrect behavior on Windows because of hardcoded delimiter
